### PR TITLE
Add missing header

### DIFF
--- a/src/dumbno.bif
+++ b/src/dumbno.bif
@@ -1,3 +1,7 @@
+%%{
+#include <unistd.h>
+%%}
+
 function send_json_udp%(host: string, rport: count, body: string%): bool
    %{
     int sock;


### PR DESCRIPTION
Compilation failed with Zeek 3.0-RC1 on CentOS 7 without it.